### PR TITLE
[FIX][9.0] hr_holidays_half_day : number_of_days_temp computing

### DIFF
--- a/hr_holidays_half_day/models/hr_holidays.py
+++ b/hr_holidays_half_day/models/hr_holidays.py
@@ -2,7 +2,6 @@
 # Copyright 2019 Coop IT Easy SCRLfs
 #   - Vincent Van Rossem <vincent@coopiteasy.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 import math
 from pytz import timezone, UTC
 
@@ -24,31 +23,17 @@ class HrHolidays(models.Model):
         default="day",
     )
 
-    def _recompute_days(self):
-        date_from = self.date_from
-        date_to = self.date_to
-        if (date_to and date_from) and (date_from <= date_to):
-            duration = self._compute_number_of_days_from_contract(
-                self.employee_id.id, date_from, date_to
-            )
-            return duration
-
     @api.multi
     def onchange_date_from(self, date_to, date_from):
         res = super(HrHolidays, self).onchange_date_from(date_to, date_from)
-        employee_id = self.employee_id.id or self.env.context.get(
-            "employee_id", False
-        )
-        if (date_to and date_from) and (date_from <= date_to):
-            diff_day = self._compute_number_of_days_from_contract(
-                employee_id, date_from, date_to
-            )
-            res["value"]["number_of_days_temp"] = diff_day
-        return res
+        return self._update_values(date_to, date_from, res)
 
     @api.multi
     def onchange_date_to(self, date_to, date_from):
         res = super(HrHolidays, self).onchange_date_to(date_to, date_from)
+        return self._update_values(date_to, date_from, res)
+
+    def _update_values(self, date_to, date_from, res):
         employee_id = self.employee_id.id or self.env.context.get(
             "employee_id", False
         )
@@ -93,32 +78,6 @@ class HrHolidays(models.Model):
 
         return utc_date_from, utc_date_to
 
-    def _compute_number_of_days_from_contract(self, employee_id, date_from, date_to):
-        """ Returns a float equals to the timedelta between two dates given as string."""
-        hours = 0.0
-        if employee_id:
-            employee = self.env["hr.employee"].browse(employee_id)
-            company = employee.company_id
-            if not company.hours_per_day:
-                raise ValidationError(
-                    _("You must define company working hours")
-                )
-            from_dt = fields.Datetime.from_string(date_from)
-            to_dt = fields.Datetime.from_string(date_to)
-            contracts = employee.sudo().contract_ids
-            for contract in contracts:
-                for calendar in contract.working_hours:
-                    working_hours = calendar.get_working_hours(
-                        from_dt,
-                        to_dt,
-                        resource_id=calendar.id,
-                        compute_leaves=True,
-                    )
-                    hours += sum(wh for wh in working_hours)
-            if hours:
-                hours /= company.hours_per_day
-        return hours
-
     def _get_utc_date(self, day, hour, minute):
         tz = self._context.get("tz") or self.env.user.tz
         if not tz:
@@ -130,3 +89,66 @@ class HrHolidays(models.Model):
         day_local_time = context_tz.localize(day_time)
         day_utc_time = day_local_time.astimezone(UTC)
         return day_utc_time
+
+    def _compute_number_of_days_from_contract(
+        self, employee_id, date_from, date_to
+    ):
+        """ Returns a float equals to the timedelta between two dates given as string."""
+        hours = 0.0
+        if employee_id:
+            employee = self.env["hr.employee"].browse(employee_id)
+            company = employee.company_id
+            if not company.hours_per_day:
+                raise ValidationError(
+                    _("You must define company working hours")
+                )
+            hours = (
+                self.get_working_hours(employee, date_from, date_to)
+                / company.hours_per_day
+            )
+
+        return hours
+
+    @api.multi
+    def get_working_hours(self, employee, date_from, date_to):
+        """
+        Get the working hours for a given date according to employee's contracts
+        @return: total of working hours
+        """
+        from_dt = fields.Datetime.from_string(date_from)
+        to_dt = fields.Datetime.from_string(date_to)
+
+        total = 0.0
+        contracts = self.get_contracts(employee, date_from, date_to)
+        for contract in contracts:
+            for calendar in contract.working_hours:
+                total += sum(
+                    wh
+                    for wh in calendar.get_working_hours(
+                        start_dt=from_dt, end_dt=to_dt,
+                    )
+                )
+        return total
+
+    def get_contracts(self, employee, date_from, date_to):
+        """
+        Get employee's contracts whose given date are included
+        in the start date and the end date (defined or not) of the contract
+        @return: hr.contract object
+        """
+        return (
+            self.env["hr.contract"]
+            .sudo()
+            .search([("employee_id.id", "=", employee.id),])
+            .filtered(
+                lambda r: (
+                    fields.Date.from_string(r.date_start)
+                    <= fields.Date.from_string(date_from)
+                )
+                and (
+                    not r.date_end
+                    or fields.Date.from_string(date_to)
+                    <= fields.Date.from_string(r.date_end)
+                )
+            )
+        )

--- a/hr_holidays_half_day/views/hr_holidays_view.xml
+++ b/hr_holidays_half_day/views/hr_holidays_view.xml
@@ -11,16 +11,10 @@
                     <attribute name="create">false</attribute>
                 </form>
                 <field name="date_from" position="attributes">
-                    <attribute name="context">{'employee_id': employee_id, 'holiday_status_id': holiday_status_id}</attribute>
                     <attribute name="readonly">1</attribute>
                 </field>
                 <field name="date_to" position="attributes">
-                    <attribute name="context">{'employee_id': employee_id, 'holiday_status_id': holiday_status_id}</attribute>
                     <attribute name="readonly">1</attribute>
-                </field>
-                <field name="employee_id" position="attributes">
-                    <attribute name="context">{'date_from': date_from, 'date_to': date_to, 'holiday_status_id': holiday_status_id}</attribute>
-                    <attribute name="on_change">onchange_employee(employee_id, context)</attribute>
                 </field>
                 <field name="number_of_days_temp" position="attributes">
                     <attribute name="attrs">{'readonly':[('type', '=', 'remove'),('state','!=','draft')]}</attribute>


### PR DESCRIPTION
`number_of_days_temp` is now computed :
- only when `date_from` and/or  `date_to` change (triggered by a change on am/pm/day `period`).
- according to an employee's contracts

Limitation / Known issue : 
- Cannot get employee's contracts when leaves overlap `date_end` of one contract and `date_start` of another
